### PR TITLE
F/underscore names - fix #28

### DIFF
--- a/abi-data/abis/UnderscoreNames.json
+++ b/abi-data/abis/UnderscoreNames.json
@@ -1,0 +1,11 @@
+[
+  {
+    "constant": false,
+    "inputs": [
+    ],
+    "name": "_functionWithUnderscore",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+  }
+]

--- a/src/Data/Generator.purs
+++ b/src/Data/Generator.purs
@@ -70,6 +70,12 @@ capitalize s =
       rest = drop 1 s
   in h <> rest
 
+ensureValidType :: String -> String
+ensureValidType s =
+  let startChar = take 1 s
+  -- if the first character is the same when both lowercase and uppercase it cannot be a valid type name (e.g. underscores)
+  in if toUpper startChar == toLower startChar then "FnT" <> s else s
+
 lowerCase :: String -> String
 lowerCase s =
   let h = toLower $ take 1 s
@@ -158,7 +164,7 @@ funToTypeDecl fun@(SolidityFunction f) opts = do
     toPSType $ fi.type
   pure $
     FunTypeDecl
-      { typeName: capitalize $ opts.exprPrefix <> f.name <> "Fn"
+      { typeName: ensureValidType $ capitalize $ opts.exprPrefix <> f.name <> "Fn"
       , factorTypes
       , signature: toSignature fun
       }


### PR DESCRIPTION
Fixes #28 

- Append invalid type names with "FnT" to make valid

Note: not sure if the test I put in there is good enough but it does catch the underscore case

Also, this is nicer than using `--prefix` because
* it works regardless of whether people know about `--prefix`
* and `--prefix` will pollute all the method names too, not just function names
* the types used aren't nearly as commonly used (if ever) as the method names (they are exported though)
* doesn't change other function names or types - so nonbreaking change (since underscored functions didn't work anyway)