### PR TITLE
Fix of `Pulp` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ main = generatorMain
 
 ```sh
 
-pulp -m Generator --src-path generator run -- --abis <abis> --dest src --module Contracts ...
+pulp run -m Generator --src-path generator -- --abis <abis> --dest src --module Contracts
 
 ```
 
@@ -53,8 +53,8 @@ pulp -m Generator --src-path generator run -- --abis <abis> --dest src --module 
 Until [this issue](https://github.com/purescript-contrib/pulp/issues/309) is fixed, we have to temporarily replace the step above with something like this
 
 ```sh
-pulp -m Generator --src-path generator build --to generator.js
-node generator.js --abis <abis> --dest src --module Contracts ...
+pulp build -m Generator --src-path generator --to generator.js
+node generator.js --abis <abis> --dest src --module Contracts
 rm generator.js
 ```
 


### PR DESCRIPTION
to avoid `* Error: Unknown command: "-m"` by using latest `Pulp` `v.12.0.1` (tested on Linux/Ubuntu). Note the order of `run` or `build`.