### PR TITLE
fix dynamic / statically sized array parsing

### DIFF
--- a/abi-data/abis/TTC.json
+++ b/abi-data/abis/TTC.json
@@ -1,0 +1,300 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC721",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IBonsaiRelay",
+        "name": "bonsaiRelay",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_imageId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "enum TTCTrading.TradePhase",
+        "name": "newPhase",
+        "type": "uint8"
+      }
+    ],
+    "name": "PhaseChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256[6]",
+        "name": "tokenIdsArray",
+        "type": "uint256[6]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[][6]",
+        "name": "preferenceListsArray",
+        "type": "uint256[][6]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[][]",
+        "name": "result",
+        "type": "uint256[][]"
+      }
+    ],
+    "name": "TTCResult",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256[6]",
+        "name": "tokenIds",
+        "type": "uint256[6]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[][6]",
+        "name": "preferenceLists",
+        "type": "uint256[][6]"
+      }
+    ],
+    "name": "TokenDetailsEmitted",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_PARTICIPANTS",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bonsaiRelay",
+    "outputs": [
+      {
+        "internalType": "contract IBonsaiRelay",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "imageId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lockRankingAndExecuteTTC",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownersArray",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "phase",
+    "outputs": [
+      {
+        "internalType": "enum TTCTrading.TradePhase",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "preferenceListsArray",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "retrieveToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sealTokensAndStartRanking",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[][]",
+        "name": "_result",
+        "type": "uint256[][]"
+      }
+    ],
+    "name": "storeResult",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "submissionCounter",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_preferenceList",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "submitPreferences",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "submitToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [
+      {
+        "internalType": "contract IERC721",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenContractsArray",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenIdsArray",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]
+

--- a/src/Data/AbiParser.purs
+++ b/src/Data/AbiParser.purs
@@ -13,13 +13,14 @@ import Data.Argonaut.Encode.Class (encodeJson)
 import Data.Array (fromFoldable, null)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
-import Data.Foldable (all, foldMap)
+import Data.Foldable (all, foldMap, foldr)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Generic.Rep (class Generic)
 import Data.Eq.Generic (genericEq)
 import Data.Show.Generic (genericShow)
 import Data.Int (fromString)
-import Data.List.Types (List(..), NonEmptyList(..))
+import Data.List (reverse)
+import Data.List.Types (List(..))
 import Data.Maybe (Maybe(..))
 import Data.NonEmpty ((:|))
 import Data.String.CodeUnits (fromCharArray)
@@ -45,7 +46,7 @@ data SolidityType
   | SolidityString
   | SolidityBytesN Int
   | SolidityBytesD
-  | SolidityVector (NonEmptyList Int) SolidityType
+  | SolidityVector Int SolidityType
   | SolidityArray SolidityType
 
 derive instance genericSolidityType :: Generic SolidityType _
@@ -65,7 +66,7 @@ instance formatSolidityType :: Format SolidityType where
     SolidityString -> "string"
     SolidityBytesN n -> "bytes" <> show n
     SolidityBytesD -> "bytes"
-    SolidityVector ns a -> format a <> foldMap (\n -> "[" <> show n <> "]") ns
+    SolidityVector n a -> format a <> "[" <> show n <> "]"
     SolidityArray a -> format a <> "[]"
 
 parseUint :: Parser SolidityType
@@ -120,20 +121,39 @@ solidityBasicTypeParser =
     , parseAddress
     ]
 
-vectoDimentionsParser :: Parser (List Int)
-vectoDimentionsParser = manyTill
-  (char '[' *> (parseDigits >>= asInt) <* char ']')
-  (lookAhead $ void (string "[]") <|> eof)
+data ArrayType = Dynamic | FixedLength Int
+
+derive instance genericArrayType :: Generic ArrayType _
+
+instance showArrayType :: Show ArrayType where
+  show x = genericShow x
+
+instance eqArrayType :: Eq ArrayType where
+  eq x = genericEq x
+
+parseArrayType :: Parser ArrayType
+parseArrayType = do 
+  let dynamic = do 
+        _ <- string "[]"
+        pure Dynamic
+      fixedLength = do 
+        _ <- char '['
+        n <- parseDigits >>= asInt
+        _ <- char ']'
+        pure $ FixedLength n
+  dynamic <|> fixedLength
+
 
 solidityTypeParser :: Parser SolidityType
 solidityTypeParser = do
   t <- solidityBasicTypeParser
-  mbVectorDims <- vectoDimentionsParser
-  let
-    t' = case mbVectorDims of
-      Nil -> t
-      Cons n ns -> SolidityVector (NonEmptyList $ n :| ns) t
-  (SolidityArray t' <$ string "[]") <|> pure t'
+  arrayTypes <- reverse <$> manyTill parseArrayType eof
+  let f at acc = case at of
+          Dynamic -> SolidityArray acc
+          FixedLength n -> SolidityVector n acc
+  pure $ foldr f t arrayTypes
+        
+        
 
 parseSolidityType :: String -> Either JsonDecodeError SolidityType
 parseSolidityType s = parseSolidityType' s # lmap \err -> Named err $ UnexpectedValue (encodeJson s)

--- a/src/Data/Generator.purs
+++ b/src/Data/Generator.purs
@@ -58,7 +58,7 @@ toPSType s = unsafePartial case s of
     pure $ Gen.typeApp (Gen.typeCtor bytesN) [ digits ]
   SolidityBytesD ->
     Gen.typeCtor <$> TidyM.importFrom "Network.Ethereum.Web3.Solidity" (TidyM.importType "ByteString")
-  SolidityVector ns a -> expandVector ns a
+  SolidityVector n a -> mkVector n a
   SolidityArray a -> do
     t <- toPSType a
     pure $ Gen.typeApp (Gen.typeCtor "Array") [ t ]
@@ -88,16 +88,11 @@ toPSType s = unsafePartial case s of
             let allRestDigits = map (Gen.binaryOp digitAnd) (snoc tailDs dType)
             pure $ Gen.typeOp (Gen.typeCtor head') allRestDigits
 
-  expandVector (List.NonEmptyList (n :| ns)) a = unsafePartial do
+  mkVector n a = unsafePartial do
     l <- makeDigits n
     vector <- Gen.typeCtor <$> TidyM.importFrom "Network.Ethereum.Web3" (TidyM.importType "Vector")
-    case List.uncons ns of
-      Nothing -> do
-        x <- toPSType a
-        pure $ Gen.typeApp vector [ l, x ]
-      Just { head, tail } -> do
-        x <- expandVector (List.NonEmptyList $ head :| tail) a
-        pure $ Gen.typeApp vector [ l, x ]
+    x <- toPSType a
+    pure $ Gen.typeApp vector [ l, x ]
 
 --------------------------------------------------------------------------------
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -29,7 +29,7 @@ simpleStorageParserSpec =
   describe "simple storage parser spec" do
     it "can parse solidity types" do
       parseSolidityType' "bytes32[2147483647][12][]" `shouldEqual`
-        Right (SolidityArray $ SolidityVector (pure top <> pure 12) (SolidityBytesN 32))
+        Right (SolidityArray $ SolidityVector 12 $ SolidityVector top (SolidityBytesN 32))
       parseSolidityType' "bytes32[1asd][]" `shouldEqual`
         Left "Failed to parse SolidityType \"bytes32[1asd][]\" with error: { error: \"Could not match character ']'\", pos: 9 }"
       parseSolidityType' "bytes32[21474836471][12][]" `shouldEqual`
@@ -37,7 +37,7 @@ simpleStorageParserSpec =
       parseSolidityType' "bytes999[]" `shouldEqual`
         Right (SolidityArray $ SolidityBytesN 999)
       parseSolidityType' "bytes32[] " `shouldEqual`
-        Left "Failed to parse SolidityType \"bytes32[] \" with error: { error: \"Expected EOF\", pos: 9 }"
+        Left "Failed to parse SolidityType \"bytes32[] \" with error: { error: \"Could not match character '['\", pos: 9 }"
 
     it "can parse the simple storage abi" do
       ejson <- jsonParser <$> readTextFile UTF8 "./abi-data/truffle/build/contracts/SimpleStorage.json"


### PR DESCRIPTION
We were doing something totally wrong before. For example, this

```solidity
uint256[][6]
```

should generate the type

```purescript
Vector (DOne D6) (Array (UIntN (D2 :& D5 :& DOne D6)))

```

Whereas currently it actually fails. Even still the logic is wrong, `[]` and `[n]` are left associative so 

```solidity
uint[3][2]
```
should parse as 

```purescript
Vector (DOne D2) Vector (DOne D3)  (UIntN (D2 :& D5 :& DOne D6)))
```

Not 

```purescript
Vector (DOne D3) Vector (DOne D2)  (UIntN (D2 :& D5 :& DOne D6)))
```
which is what we currently do