### PR TITLE
Correct number of indexed args

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -1,7 +1,3 @@
-{-
-Welcome to a Spago project!
-You can edit this file as you like.
--}
 { name = "web3-generator"
 , dependencies =
   [ "aff"

--- a/src/Data/Generator.purs
+++ b/src/Data/Generator.purs
@@ -3,7 +3,7 @@ module Data.Generator where
 import Prelude
 
 import Data.AbiParser (Abi(..), AbiType(..), FunctionInput(..), IndexedSolidityValue(..), SolidityEvent(..), SolidityFunction(..), SolidityConstructor(..), SolidityType(..), format)
-import Data.Array (filter, length, uncons, unsnoc, snoc, (:), concat, unsafeIndex, (..))
+import Data.Array (filter, length, uncons, unsnoc, snoc, (:), concat, unsafeIndex, (..), replicate)
 import Data.Array as Array
 import Data.Identity (Identity(..))
 import Data.Maybe (Maybe(..), fromJust)
@@ -587,7 +587,7 @@ eventDecls (EventData decl) = unsafePartial do
                       [ Gen.exprIdent _topics
                       , Gen.exprApp (Gen.exprCtor _just)
                           [ Gen.exprArray
-                              [ Gen.exprOp (Gen.exprCtor _just)
+                              ( Gen.exprOp (Gen.exprCtor _just)
                                   [ Gen.binaryOp "$" (Gen.exprIdent _unsafePartial)
                                   , Gen.binaryOp "$" (Gen.exprIdent _fromJust)
                                   , Gen.binaryOp "$"
@@ -595,10 +595,9 @@ eventDecls (EventData decl) = unsafePartial do
                                           [ Gen.exprString $ unHex $ eventId decl.solidityEvent ]
                                       )
                                   ]
+                                  : replicate (length decl.indexedTypes) (Gen.exprCtor _nothing)
+                              )
 
-                              , Gen.exprCtor _nothing
-                              , Gen.exprCtor _nothing
-                              ]
                           ]
                       ]
                   )

--- a/test.dhall
+++ b/test.dhall
@@ -23,7 +23,6 @@ in    conf
             , "node-buffer"
             , "node-fs"
             , "node-path"
-            , "nonempty"
             , "partial"
             , "profunctor-lenses"
             , "strings"


### PR DESCRIPTION
The number of `Nothing`s representing the indexed field wildcards was correct prior to  #67 . This PR corrects the error